### PR TITLE
Fixed the number of Exits being displayed

### DIFF
--- a/app/src/main/java/mavonie/subterminal/Dashboard.java
+++ b/app/src/main/java/mavonie/subterminal/Dashboard.java
@@ -97,7 +97,7 @@ public class Dashboard extends Fragment {
         skydiveCount.setText(Integer.toString(Subterminal.getUser().getSettings().getSkydiveStartJumpNo() + new Skydive().count(Synchronizable.getActiveParams())));
         baseCount.setText(Integer.toString(Subterminal.getUser().getSettings().getBaseStartJumpNo() + new Jump().count(Synchronizable.getActiveParams())));
         dropzoneCount.setText(Integer.toString(Dropzone.getDropzonesVisitedCount()));
-        exitsCount.setText(Integer.toString(new Exit().count()));
+        exitsCount.setText(Integer.toString(new Exit().count(Synchronizable.getActiveParams())));
 
         setPieChartData();
         setBarChartData();

--- a/app/src/main/res/layout/fragment_jump_view.xml
+++ b/app/src/main/res/layout/fragment_jump_view.xml
@@ -17,7 +17,7 @@
 
             <android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
-                                                android:id="@+id/card_view"
+                android:id="@+id/card_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:cardCornerRadius="4dp"


### PR DESCRIPTION
The issue was with the count() being called in SQLiteModel. We must use
the other method that takes in a HashMap<> to perform the proper query
operation on the Sql database. Adding Synchronizable.getActiveParams()
accomplishes this task by returning only the database rows where deleted
is not 0.

P.S. Also fixed an indentation in fragment_jump_view! :+1: